### PR TITLE
Fix faulty diagrams behaviour

### DIFF
--- a/foliant/preprocessors/plantuml.py
+++ b/foliant/preprocessors/plantuml.py
@@ -2,6 +2,8 @@
 PlantUML diagrams preprocessor for Foliant documenation authoring tool.
 '''
 
+import os
+
 from pathlib import Path
 from hashlib import md5
 from subprocess import run, PIPE, STDOUT, CalledProcessError
@@ -114,6 +116,9 @@ class Preprocessor(BasePreprocessor):
 
         except CalledProcessError as exception:
             self.logger.error(str(exception))
+
+            # rename the diagram file for us not to use it as cached on the next run
+            diagram_path.rename('_error'.join(os.path.splitext(diagram_path)))
 
             raise RuntimeError(
                 f'Processing of PlantUML diagram {diagram_src_path} failed: {exception.output.decode()}'

--- a/foliant/preprocessors/plantuml.py
+++ b/foliant/preprocessors/plantuml.py
@@ -120,9 +120,11 @@ class Preprocessor(BasePreprocessor):
             # rename the diagram file for us not to use it as cached on the next run
             diagram_path.rename('_error'.join(os.path.splitext(diagram_path)))
 
-            raise RuntimeError(
-                f'Processing of PlantUML diagram {diagram_src_path} failed: {exception.output.decode()}'
-            )
+            print(f'\nProcessing of PlantUML diagram {diagram_src_path} failed: {exception.output.decode()}')
+            return ''
+            # raise RuntimeError(
+            #     f'Processing of PlantUML diagram {diagram_src_path} failed: {exception.output.decode()}'
+            # )
 
         return img_ref
 


### PR DESCRIPTION
1st commit: rename faulty diagrams output files for preprocessor not to take them for cached
2nd commit: just skip faulty diagrams and inform the user about them. The diagrams will be replaced with an empty string and the user will be informed about the error in the console