### PR TITLE
Fixed svg links not working (#3)

### DIFF
--- a/README.md
+++ b/README.md
@@ -93,3 +93,5 @@ By default, diagrams are in PNG. But this diagram is in EPS:
 ```
 
 Sometimes it can be necessary to process auto-generated documents that contain multiple PlantUML diagrams definitions without using Foliant-specific tags syntax. Use the `parse_raw` option in these cases.
+
+If the `format` param is set to `svg`, the preprocessor will output raw SVG data directly into the resulting HTML. To prevent this behavior, set the `as_image` param to `true`.

--- a/foliant/preprocessors/plantuml.py
+++ b/foliant/preprocessors/plantuml.py
@@ -100,7 +100,11 @@ class Preprocessor(BasePreprocessor):
         if diagram_path.exists():
             self.logger.debug('Diagram image found in cache')
 
-            return img_ref
+            if diagram_format != 'svg' or {**params, **options}.get('as_image', False):
+                return img_ref
+            else:
+                with open(diagram_path, 'r') as image_file:
+                    return image_file.read()
 
         diagram_src_path.parent.mkdir(parents=True, exist_ok=True)
 
@@ -145,7 +149,11 @@ class Preprocessor(BasePreprocessor):
             else:
                 raise RuntimeError(f'Failed: {exception.output.decode()}')
 
-        return img_ref
+        if diagram_format != 'svg' or {**params, **options}.get('as_image', False):
+            return img_ref
+        else:
+            with open(diagram_path, 'r') as image_file:
+                return image_file.read()
 
     def process_plantuml(self, content: str) -> str:
         '''Find diagram definitions and replace them with image refs.


### PR DESCRIPTION
Changing the default behavior of the preprocessor to output raw svg when the format is svg. To prevent this, the `as_image` param can be set to `true`.