### PR TITLE
Feature/add src attribute

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -1,3 +1,7 @@
+# unreleased
+
+-   Add `src` attribute to plantuml tag to read diagram from file.
+
 # 1.0.10
 
 -   New utils module.

--- a/test/data/diagram.puml
+++ b/test/data/diagram.puml
@@ -1,0 +1,10 @@
+@startuml
+
+if (has_tag) then (yes)
+    :read from file;
+
+else
+    :read tag body;
+endif
+
+@enduml

--- a/test/data/read_from_tag.md
+++ b/test/data/read_from_tag.md
@@ -1,0 +1,4 @@
+# Read PlantUML from file
+
+<plantuml src="./diagram.puml">
+</plantuml>

--- a/test/test_funcitons.py
+++ b/test/test_funcitons.py
@@ -1,7 +1,7 @@
 from unittest import TestCase
 from pathlib import Path
 
-from foliant.preprocessors.utils.combined_options import Options
+from foliant.contrib.combined_options import Options
 from foliant.preprocessors.plantuml import get_diagram_format
 from foliant.preprocessors.plantuml import parse_diagram_source
 from foliant.preprocessors.plantuml import generate_args

--- a/test/test_plantuml.py
+++ b/test/test_plantuml.py
@@ -99,3 +99,17 @@ class TestPlantuml(TestCase):
 
         images = re.findall(r'<svg .+?</svg>', result, flags=re.DOTALL)
         self.assertEqual(len(images), 2)
+
+    def test_read_from_file(self):
+        self.ptf.test_preprocessor(
+            input_mapping=unpack_file_dict(
+                {
+                    'index.md': rel_name('data/read_from_tag.md'),
+                    'diagram.puml': rel_name('data/diagram.puml'),
+                }
+            )
+        )
+
+        result = self.ptf.results['index.md']
+        images = re.findall(r'!\[\]\(.+\)', result)
+        self.assertEqual(len(images), 1)


### PR DESCRIPTION
## Why

Certain editors for plantuml only show a live preview of the diagram based on the extension of the file (.puml). 


Note: The path lookup logic on line 191 might need some adjustment after user feedback.
Note2: OSError is caught to follow existing logic of not failing the generation when the preprocessor fails.